### PR TITLE
Added output of error messages for request IDs for each test

### DIFF
--- a/lib/runner/reporters/junit.xml.ejs
+++ b/lib/runner/reporters/junit.xml.ejs
@@ -20,6 +20,14 @@
         <%= systemerr %>
       </system-err><% } %>
   <% } %>
+
+  <% if (module.errmessages) { %>
+    <% for (var i = 0; i < module.errmessages.length; i++) {
+      var errMsg = module.errmessages[i] %>
+    <system-err><%= errMsg %> </system-err>
+    <% } %>
+  <% } %>
+
   <% if (module.skipped && (module.skipped.length > 0)) { %>
     <% for (var j = 0; j < module.skipped.length; j++) { %>
     <testcase


### PR DESCRIPTION
# Motivation

The output template for uart tests needs to be able to display any failed requests for a single test.

This is related to https://github.com/AdamSaleh/fh-uart/pull/3
# Changes

Added messages for specific test suites to be able to display any failed requests.
